### PR TITLE
rewritten recoil crosshair

### DIFF
--- a/Recoil Crosshair.lua
+++ b/Recoil Crosshair.lua
@@ -15,10 +15,8 @@ local draw_Color = draw.Color
 local draw_FilledRect = draw.FilledRect
 
 local refExtra = gui.Reference("Visuals", "Other", "Extra")
-local settingGroup = gui.Groupbox(refExtra, "Recoil Crosshair", 296, 220, 296, 0)
-local settingEnable = gui.Checkbox(settingGroup, "lua_recoilcrosshair", "Enable", false)
-local settingCustom = gui.Checkbox(settingGroup, "lua_recoilcrosshair.custom", "Custom crosshair", false)
-local settingColor = gui.ColorPicker(settingCustom, "color", "", 255, 0, 0, 255)
+local settingCombobox = gui.Combobox(refExtra, "lua_recoilcrosshair", "Recoil Crosshair", "Off", "In-game", "Custom")
+local settingColor = gui.ColorPicker(settingCombobox, "color", "", 255, 0, 0, 255)
 
 local varNameRbotEnable = "rbot.master"
 local varNameNoRecoil = "esp.other.norecoil"
@@ -47,14 +45,16 @@ local WEAPONTYPE_MACHINEGUN = 6
 
 callbacks.Register("CreateMove", function()
 	-- don't enable in-game recoil crosshair when ragebot is enabled or using no recoil
-	local value = (not gui_GetValue(varNameRbotEnable) and not gui_GetValue(varNameNoRecoil) and
-		settingEnable:GetValue() and not settingCustom:GetValue()) and 1 or 0
+	local value = (not gui_GetValue(varNameRbotEnable) and 
+		not gui_GetValue(varNameNoRecoil) and settingCombobox:GetValue() == 1) and 1 or 0
 
 	client_SetConVar("cl_crosshair_recoil", value, true)
 end)
 
 callbacks.Register("Draw", function()
-	if gui_GetValue(varNameRbotEnable) or not settingEnable:GetValue() then
+	local setting = settingCombobox:GetValue()
+	
+	if gui_GetValue(varNameRbotEnable) or setting == 0 then
 		return
 	end
 
@@ -65,7 +65,7 @@ callbacks.Register("Draw", function()
 	-- if localPlayer is nil then ineyePlayer is nil too
 	-- draw recoil crosshair when using no visual recoil or when using ingame crosshair and scoped
 	if not localPlayer or (not ineyePlayer or not ineyePlayer:IsAlive()) or
-		(not noVisRecoil and not settingCustom:GetValue() and not ineyePlayer:GetPropBool("m_bIsScoped")) then
+		(not noVisRecoil and setting ~= 2 and not ineyePlayer:GetPropBool("m_bIsScoped")) then
 		return
 	end
 

--- a/Recoil Crosshair.lua
+++ b/Recoil Crosshair.lua
@@ -16,14 +16,6 @@ local math_rad = math.rad
 local math_sin = math.sin
 local tonumber = tonumber
 
-callbacks.Register("CreateMove", function()
-	-- don't enable in-game recoil crosshair when ragebot is enabled or using no recoil
-	local value = (not gui.GetValue(varNameRbotEnable) and not gui.GetValue(varNameNoRecoil) and
-		settingEnable:GetValue() and settingIngame:GetValue()) and 1 or 0
-
-	client.SetConVar("cl_crosshair_recoil", value, true)
-end)
-
 local function GetIneyesPlayer()
 	local localPlayer = entities.GetLocalPlayer()
 	if not localPlayer then
@@ -45,6 +37,14 @@ local WEAPONTYPE_PISTOL = 1
 local WEAPONTYPE_SHOTGUN = 4
 local WEAPONTYPE_SNIPER_RIFLE = 5
 local WEAPONTYPE_MACHINEGUN = 6
+
+callbacks.Register("CreateMove", function()
+	-- don't enable in-game recoil crosshair when ragebot is enabled or using no recoil
+	local value = (not gui.GetValue(varNameRbotEnable) and not gui.GetValue(varNameNoRecoil) and
+		settingEnable:GetValue() and settingIngame:GetValue()) and 1 or 0
+
+	client.SetConVar("cl_crosshair_recoil", value, true)
+end)
 
 callbacks.Register("Draw", function()
 	if gui.GetValue(varNameRbotEnable) or not settingEnable:GetValue() then

--- a/Recoil Crosshair.lua
+++ b/Recoil Crosshair.lua
@@ -1,31 +1,34 @@
---Recoil Crosshair by Cheeseot and contributors
+-- Recoil Crosshair by Cheeseot and contributors
 
-local refExtra = gui.Reference("VISUALS", "Other", "Extra");
-local settingGroup = gui.Groupbox(refExtra, "Custom Recoil Crosshair", 296, 220, 296, 0);
-local settingEnable = gui.Checkbox(settingGroup, "lua_recoilcrosshair", "Enable", false);
-local settingColor = gui.ColorPicker(settingEnable, "color", "", 255, 0, 0, 255);
-local settingIngame = gui.Checkbox(settingGroup, "lua_recoilcrosshair_ingame", "Use in-game crosshair", false);
+local refExtra = gui.Reference("Visuals", "Other", "Extra")
+local settingGroup = gui.Groupbox(refExtra, "Custom Recoil Crosshair", 296, 220, 296, 0)
+local settingEnable = gui.Checkbox(settingGroup, "lua_recoilcrosshair", "Enable", true)
+local settingColor = gui.ColorPicker(settingEnable, "color", "", 255, 0, 0, 255)
+local settingIngame = gui.Checkbox(settingGroup, "lua_recoilcrosshair.ingame", "Use in-game crosshair", true)
 
 callbacks.Register("CreateMove", function()
-	local value = (not gui.GetValue("rbot.master") and settingEnable:GetValue() and settingIngame:GetValue()) and 1 or 0; 
-	client.SetConVar("cl_crosshair_recoil", value, true);
-end);
+	-- don't enable in-game recoil crosshair when ragebot is enabled or using no recoil
+	local value = (not gui.GetValue("rbot.master") and not gui.GetValue("esp.other.norecoil") and 
+		settingEnable:GetValue() and settingIngame:GetValue()) and 1 or 0
+
+	client.SetConVar("cl_crosshair_recoil", value, true)
+end)
 
 local function GetIneyesPlayer()
-	local localPlayer = entities.GetLocalPlayer();
+	local localPlayer = entities.GetLocalPlayer()
 	if not localPlayer then
-		return nil;
+		return nil
 	end
-	
-	if not localPlayer:IsAlive() then
-		local obsTarget = localPlayer:GetPropEntity("m_hObserverTarget");
-		if not obsTarget or not obsTarget:IsPlayer() then
-			return nil;
-		end
-		return obsTarget;
+
+	if localPlayer:IsAlive() then
+		return localPlayer
 	end
-	
-	return localPlayer;
+
+	local obsTarget = localPlayer:GetPropEntity("m_hObserverTarget")
+	if not obsTarget or not obsTarget:IsPlayer() then
+		return nil
+	end
+	return obsTarget
 end
 
 -- locals are faster than globals
@@ -33,58 +36,70 @@ end
 local math_tan = math.tan
 local math_rad = math.rad
 local math_sin = math.sin
+local tonumber = tonumber
+
+local WEAPONTYPE_PISTOL = 1
+local WEAPONTYPE_SHOTGUN = 4
+local WEAPONTYPE_SNIPER_RIFLE = 5
+local WEAPONTYPE_MACHINEGUN = 6
 
 callbacks.Register("Draw", function()
 	if gui.GetValue("rbot.master") or not settingEnable:GetValue() then
-		return;
+		return
+	end
+	
+	local noRecoil = gui.GetValue("esp.other.norecoil")
+	
+	local localPlayer = entities.GetLocalPlayer()
+	local player = GetIneyesPlayer()
+	-- if localPlayer is nil then player:IsAlive is nil too
+	-- draw recoil crosshair when using no recoil or when using ingame crosshair but scoped
+	if not localPlayer or (not player or not player:IsAlive()) or
+		(not noRecoil and settingIngame:GetValue() and not player:GetPropBool("m_bIsScoped")) then
+		return
 	end
 
-	local localPlayer = entities.GetLocalPlayer();
-	local player = GetIneyesPlayer();
-	if not localPlayer or (not player or not player:IsAlive()) or
-		(settingIngame:GetValue() and not player:GetPropBool("m_bIsScoped")) then
-		return;
-	end
-	
-	local activeWeapon = player:GetPropEntity("m_hActiveWeapon");
+	local activeWeapon = player:GetPropEntity("m_hActiveWeapon")
 	if not activeWeapon or activeWeapon:GetPropFloat("m_flRecoilIndex") <= 1 then
-		return;
+		return
 	end
-	
-	local weaponType = activeWeapon:GetWeaponType();
-	if 1 > weaponType or weaponType > 6 or weaponType == 4 or weaponType == 5 then
-		return;
+
+	local weaponType = activeWeapon:GetWeaponType()
+	if WEAPONTYPE_PISTOL > weaponType or weaponType > WEAPONTYPE_MACHINEGUN or 
+		weaponType == WEAPONTYPE_SHOTGUN or 
+		weaponType == WEAPONTYPE_SNIPER_RIFLE then
+		return
 	end
-	
-	local fov = player:GetPropInt("m_iFOV");
+
+	local fov = player:GetPropInt("m_iFOV")
 	if fov <= 0 then
-		fov = player:GetPropInt("m_iDefaultFOV");
+		fov = player:GetPropInt("m_iDefaultFOV")
 	end
-	
-	local punchAngle = localPlayer:GetPropVector("localdata", "m_Local", "m_aimPunchAngle");
-	local screenW, screenH = draw.GetScreenSize();
-	local centerX = screenW * 0.5;
-	local centerY = screenH * 0.5;
-	
-	local VIEWPUNCH_COMPENSATE_MAGIC_SCALAR = 0.65;
-	if gui.GetValue("esp.other.norecoil") then
-		VIEWPUNCH_COMPENSATE_MAGIC_SCALAR = 
-			VIEWPUNCH_COMPENSATE_MAGIC_SCALAR * tonumber(client.GetConVar("weapon_recoil_scale"));
+
+	local punchAngle = localPlayer:GetPropVector("localdata", "m_Local", "m_aimPunchAngle")
+	local screenW, screenH = draw.GetScreenSize()
+	local centerX = screenW * 0.5
+	local centerY = screenH * 0.5
+
+	local VIEWPUNCH_COMPENSATE_MAGIC_SCALAR = 0.65
+	if noRecoil then
+		VIEWPUNCH_COMPENSATE_MAGIC_SCALAR =
+			VIEWPUNCH_COMPENSATE_MAGIC_SCALAR * tonumber(client.GetConVar("weapon_recoil_scale"))
 	end
-	
+
 	-- https://github.com/perilouswithadollarsign/cstrike15_src/blob/master/game/shared/cstrike15/weapon_csbase.cpp#L2109
-	local flAngleToScreenPixel = VIEWPUNCH_COMPENSATE_MAGIC_SCALAR * 2 * ( screenH / ( 2.0 * math_tan( math_rad( fov ) * 0.5 ) ) );
-	local recoilX = centerX - ( flAngleToScreenPixel * math_sin( math_rad( punchAngle.y ) ) );
-	local recoilY = centerY + ( flAngleToScreenPixel * math_sin( math_rad( punchAngle.x ) ) );
-	
-	local diffX = recoilX - centerX;
-	local diffY = recoilY - centerY;
-	
+	local flAngleToScreenPixel = VIEWPUNCH_COMPENSATE_MAGIC_SCALAR * 2 * ( screenH / ( 2.0 * math_tan( math_rad( fov ) * 0.5 ) ) )
+	local recoilX = centerX - ( flAngleToScreenPixel * math_sin( math_rad( punchAngle.y ) ) )
+	local recoilY = centerY + ( flAngleToScreenPixel * math_sin( math_rad( punchAngle.x ) ) )
+
+	local diffX = recoilX - centerX
+	local diffY = recoilY - centerY
+
 	if (5 > diffX and diffX > -5) and (5 > diffY and diffY > -5) then
-		return;
+		return
 	end
-	
-	draw.Color(settingColor:GetValue());
-	draw.FilledRect(recoilX - 3, recoilY - 1, recoilX + 3, recoilY + 1);
-	draw.FilledRect(recoilX - 1, recoilY - 3, recoilX + 1, recoilY + 3);
-end);
+
+	draw.Color(settingColor:GetValue())
+	draw.FilledRect(recoilX - 3, recoilY - 1, recoilX + 3, recoilY + 1)
+	draw.FilledRect(recoilX - 1, recoilY - 3, recoilX + 1, recoilY + 3)
+end)

--- a/Recoil Crosshair.lua
+++ b/Recoil Crosshair.lua
@@ -1,14 +1,23 @@
 -- Recoil Crosshair by Cheeseot and contributors
 
+local refRagebotEnable = gui.Reference("Ragebot", "Master Switch")
+local refNoRecoil = gui.Reference("Visuals", "Other", "Effects", "Effects Removal", "No Recoil")
 local refExtra = gui.Reference("Visuals", "Other", "Extra")
 local settingGroup = gui.Groupbox(refExtra, "Custom Recoil Crosshair", 296, 220, 296, 0)
 local settingEnable = gui.Checkbox(settingGroup, "lua_recoilcrosshair", "Enable", true)
 local settingColor = gui.ColorPicker(settingEnable, "color", "", 255, 0, 0, 255)
 local settingIngame = gui.Checkbox(settingGroup, "lua_recoilcrosshair.ingame", "Use in-game crosshair", true)
 
+-- optimization, locals are faster than globals
+-- https://lua-users.org/wiki/OptimisingUsingLocalVariables
+local math_tan = math.tan
+local math_rad = math.rad
+local math_sin = math.sin
+local tonumber = tonumber
+
 callbacks.Register("CreateMove", function()
 	-- don't enable in-game recoil crosshair when ragebot is enabled or using no recoil
-	local value = (not gui.GetValue("rbot.master") and not gui.GetValue("esp.other.norecoil") and 
+	local value = (not refRagebotEnable:GetValue() and not refNoRecoil:GetValue() and 
 		settingEnable:GetValue() and settingIngame:GetValue()) and 1 or 0
 
 	client.SetConVar("cl_crosshair_recoil", value, true)
@@ -31,24 +40,17 @@ local function GetIneyesPlayer()
 	return obsTarget
 end
 
--- locals are faster than globals
--- https://lua-users.org/wiki/OptimisingUsingLocalVariables
-local math_tan = math.tan
-local math_rad = math.rad
-local math_sin = math.sin
-local tonumber = tonumber
-
 local WEAPONTYPE_PISTOL = 1
 local WEAPONTYPE_SHOTGUN = 4
 local WEAPONTYPE_SNIPER_RIFLE = 5
 local WEAPONTYPE_MACHINEGUN = 6
 
 callbacks.Register("Draw", function()
-	if gui.GetValue("rbot.master") or not settingEnable:GetValue() then
+	if refRagebotEnable:GetValue() or not settingEnable:GetValue() then
 		return
 	end
 	
-	local noRecoil = gui.GetValue("esp.other.norecoil")
+	local noRecoil = refNoRecoil:GetValue()
 	
 	local localPlayer = entities.GetLocalPlayer()
 	local player = GetIneyesPlayer()

--- a/Recoil Crosshair.lua
+++ b/Recoil Crosshair.lua
@@ -6,6 +6,9 @@ local settingEnable = gui.Checkbox(settingGroup, "lua_recoilcrosshair", "Enable"
 local settingColor = gui.ColorPicker(settingEnable, "color", "", 255, 0, 0, 255)
 local settingIngame = gui.Checkbox(settingGroup, "lua_recoilcrosshair.ingame", "Use in-game crosshair", true)
 
+local varNameRbotEnable = "rbot.master"
+local varNameNoRecoil = "esp.other.norecoil"
+
 -- optimization, locals are faster than globals
 -- https://lua-users.org/wiki/OptimisingUsingLocalVariables
 local math_tan = math.tan
@@ -15,7 +18,7 @@ local tonumber = tonumber
 
 callbacks.Register("CreateMove", function()
 	-- don't enable in-game recoil crosshair when ragebot is enabled or using no recoil
-	local value = (not gui.GetValue("rbot.master") and not gui.GetValue("esp.other.norecoil") and 
+	local value = (not gui.GetValue(varNameRbotEnable) and not gui.GetValue(varNameNoRecoil) and
 		settingEnable:GetValue() and settingIngame:GetValue()) and 1 or 0
 
 	client.SetConVar("cl_crosshair_recoil", value, true)
@@ -44,12 +47,12 @@ local WEAPONTYPE_SNIPER_RIFLE = 5
 local WEAPONTYPE_MACHINEGUN = 6
 
 callbacks.Register("Draw", function()
-	if gui.GetValue("rbot.master") or not settingEnable:GetValue() then
+	if gui.GetValue(varNameRbotEnable) or not settingEnable:GetValue() then
 		return
 	end
-	
-	local noRecoil = gui.GetValue("esp.other.norecoil")
-	
+
+	local noRecoil = gui.GetValue(varNameNoRecoil)
+
 	local localPlayer = entities.GetLocalPlayer()
 	local player = GetIneyesPlayer()
 	-- if localPlayer is nil then player:IsAlive is nil too
@@ -65,8 +68,8 @@ callbacks.Register("Draw", function()
 	end
 
 	local weaponType = activeWeapon:GetWeaponType()
-	if WEAPONTYPE_PISTOL > weaponType or weaponType > WEAPONTYPE_MACHINEGUN or 
-		weaponType == WEAPONTYPE_SHOTGUN or 
+	if WEAPONTYPE_PISTOL > weaponType or weaponType > WEAPONTYPE_MACHINEGUN or
+		weaponType == WEAPONTYPE_SHOTGUN or
 		weaponType == WEAPONTYPE_SNIPER_RIFLE then
 		return
 	end

--- a/Recoil Crosshair.lua
+++ b/Recoil Crosshair.lua
@@ -1,7 +1,5 @@
 -- Recoil Crosshair by Cheeseot and contributors
 
-local refRagebotEnable = gui.Reference("Ragebot", "Master Switch")
-local refNoRecoil = gui.Reference("Visuals", "Other", "Effects", "Effects Removal", "No Recoil")
 local refExtra = gui.Reference("Visuals", "Other", "Extra")
 local settingGroup = gui.Groupbox(refExtra, "Custom Recoil Crosshair", 296, 220, 296, 0)
 local settingEnable = gui.Checkbox(settingGroup, "lua_recoilcrosshair", "Enable", true)
@@ -17,7 +15,7 @@ local tonumber = tonumber
 
 callbacks.Register("CreateMove", function()
 	-- don't enable in-game recoil crosshair when ragebot is enabled or using no recoil
-	local value = (not refRagebotEnable:GetValue() and not refNoRecoil:GetValue() and 
+	local value = (not gui.GetValue("rbot.master") and not gui.GetValue("esp.other.norecoil") and 
 		settingEnable:GetValue() and settingIngame:GetValue()) and 1 or 0
 
 	client.SetConVar("cl_crosshair_recoil", value, true)
@@ -46,11 +44,11 @@ local WEAPONTYPE_SNIPER_RIFLE = 5
 local WEAPONTYPE_MACHINEGUN = 6
 
 callbacks.Register("Draw", function()
-	if refRagebotEnable:GetValue() or not settingEnable:GetValue() then
+	if gui.GetValue("rbot.master") or not settingEnable:GetValue() then
 		return
 	end
 	
-	local noRecoil = refNoRecoil:GetValue()
+	local noRecoil = gui.GetValue("esp.other.norecoil")
 	
 	local localPlayer = entities.GetLocalPlayer()
 	local player = GetIneyesPlayer()

--- a/Recoil Crosshair.lua
+++ b/Recoil Crosshair.lua
@@ -1,91 +1,90 @@
---Recoil Crosshair by Cheeseot
-local ButtonPosition = gui.Reference( "VISUALS", "Other", "Extra" );
-local PunchCheckbox = gui.Checkbox( ButtonPosition, "lua_recoilcrosshair", "Recoil Crosshair", 1 );
-local recoilcolor = gui.ColorPicker(PunchCheckbox, "recoilcolor", "Recoil Crosshair Color", 255,255,255,255)
-local IdleCheckbox = gui.Checkbox( ButtonPosition, "lua_recoilidle", "Hide Recoil Crosshair When Idle", 1 );
+--Recoil Crosshair by Cheeseot and contributors
 
-local function punch()
+local refExtra = gui.Reference("VISUALS", "Other", "Extra");
+local settingGroup = gui.Groupbox(refExtra, "Custom Recoil Crosshair", 296, 220, 296, 0);
+local settingEnable = gui.Checkbox(settingGroup, "lua_recoilcrosshair", "Enable", false);
+local settingColor = gui.ColorPicker(settingEnable, "color", "", 255, 0, 0, 255);
+local settingIngame = gui.Checkbox(settingGroup, "lua_recoilcrosshair_ingame", "Use in-game crosshair", false);
 
-local rifle = 0;
-local me = entities.GetLocalPlayer();
-if me ~= nil and not gui.GetValue("rbot.master") then
-    if me:IsAlive() then
-    local scoped = me:GetProp("m_bIsScoped");
-    if scoped == 256 then scoped = 0 end
-    if scoped == 257 then scoped = 1 end
-    local my_weapon = me:GetPropEntity("m_hActiveWeapon");
-    if my_weapon ~=nil then
-        local weapon_name = my_weapon:GetClass();
-        local canDraw = 0;
-        local snipercrosshair = 0;
-        weapon_name = string.gsub(weapon_name, "CWeapon", "");
-        if weapon_name == "Aug" or weapon_name == "SG556" then
-            rifle = 1;
-            else
-            rifle = 0;
-            end
+callbacks.Register("CreateMove", function()
+	local value = (not gui.GetValue("rbot.master") and settingEnable:GetValue() and settingIngame:GetValue()) and 1 or 0; 
+	client.SetConVar("cl_crosshair_recoil", value, true);
+end);
 
-        if scoped == 0 or (scoped == 1 and rifle == 1) then
-            canDraw = 1;
-            else
-            canDraw = 0;
-            end
-
-        if weapon_name == "Taser" or weapon_name == "CKnife" then
-            canDraw = 0;
-            end
-
-        if weapon_name == "AWP" or weapon_name == "SCAR20" or weapon_name == "G3SG1"  or weapon_name == "SSG08" then
-            snipercrosshair = 1;
-            end
-
-    --Recoil Crosshair by Cheeseot
-
-        if PunchCheckbox:GetValue() and canDraw == 1 then
-            local punchAngleVec = me:GetPropVector("localdata", "m_Local", "m_aimPunchAngle");
-            local punchAngleX, punchAngleY = punchAngleVec.x, punchAngleVec.y
-            local w, h = draw.GetScreenSize();
-            local x = w / 2;
-            local y = h / 2;
-            local fov = 90 --gui.GetValue("vis_view_fov");      polak pls add this back
-
-            if fov == 0 then
-                fov = 90;
-                end
-            if scoped == 1 and rifle == 1 then
-                fov = 45;
-                end
-            
-            local dx = w / fov;
-            local dy = h / fov;
-			
-			local px = 0
-			local py = 0
-			
-            if gui.GetValue("esp.other.norecoil") then
-				px = x - (dx * punchAngleY)*1.2;
-				py = y + (dy * punchAngleX)*2;
-            else
-				px = x - (dx * punchAngleY)*0.6;
-				py = y + (dy * punchAngleX);
-			end
-            
-            if px > x-0.5 and px < x then px = x end
-            if px < x+0.5 and px > x then px = x end
-            if py > y-0.5 and py < y then py = y end
-            if py < y+0.5 and py > y then py = y end
-
-			if IdleCheckbox:GetValue() then
-            if px == x and py == y and snipercrosshair ~=1 then return; end
-			end
-				
-            draw.Color(recoilcolor:GetValue());
-            draw.FilledRect(px-3, py-1, px+3, py+1);
-            draw.FilledRect(px-1, py-3, px+1, py+3);
-            end
-        end
-    end
-    end
+local function GetIneyesPlayer()
+	local localPlayer = entities.GetLocalPlayer();
+	if not localPlayer then
+		return nil;
+	end
+	
+	if not localPlayer:IsAlive() then
+		local obsTarget = localPlayer:GetPropEntity("m_hObserverTarget");
+		if not obsTarget or not obsTarget:IsPlayer() then
+			return nil;
+		end
+		return obsTarget;
+	end
+	
+	return localPlayer;
 end
-callbacks.Register("Draw", "punch", punch);
---Recoil Crosshair by Cheeseot
+
+-- locals are faster than globals
+-- https://lua-users.org/wiki/OptimisingUsingLocalVariables
+local math_tan = math.tan
+local math_rad = math.rad
+local math_sin = math.sin
+
+callbacks.Register("Draw", function()
+	if gui.GetValue("rbot.master") or not settingEnable:GetValue() then
+		return;
+	end
+
+	local localPlayer = entities.GetLocalPlayer();
+	local player = GetIneyesPlayer();
+	if not localPlayer or (not player or not player:IsAlive()) or
+		(settingIngame:GetValue() and not player:GetPropBool("m_bIsScoped")) then
+		return;
+	end
+	
+	local activeWeapon = player:GetPropEntity("m_hActiveWeapon");
+	if not activeWeapon or activeWeapon:GetPropFloat("m_flRecoilIndex") <= 1 then
+		return;
+	end
+	
+	local weaponType = activeWeapon:GetWeaponType();
+	if 1 > weaponType or weaponType > 6 or weaponType == 4 or weaponType == 5 then
+		return;
+	end
+	
+	local fov = player:GetPropInt("m_iFOV");
+	if fov <= 0 then
+		fov = player:GetPropInt("m_iDefaultFOV");
+	end
+	
+	local punchAngle = localPlayer:GetPropVector("localdata", "m_Local", "m_aimPunchAngle");
+	local screenW, screenH = draw.GetScreenSize();
+	local centerX = screenW * 0.5;
+	local centerY = screenH * 0.5;
+	
+	local VIEWPUNCH_COMPENSATE_MAGIC_SCALAR = 0.65;
+	if gui.GetValue("esp.other.norecoil") then
+		VIEWPUNCH_COMPENSATE_MAGIC_SCALAR = 
+			VIEWPUNCH_COMPENSATE_MAGIC_SCALAR * tonumber(client.GetConVar("weapon_recoil_scale"));
+	end
+	
+	-- https://github.com/perilouswithadollarsign/cstrike15_src/blob/master/game/shared/cstrike15/weapon_csbase.cpp#L2109
+	local flAngleToScreenPixel = VIEWPUNCH_COMPENSATE_MAGIC_SCALAR * 2 * ( screenH / ( 2.0 * math_tan( math_rad( fov ) * 0.5 ) ) );
+	local recoilX = centerX - ( flAngleToScreenPixel * math_sin( math_rad( punchAngle.y ) ) );
+	local recoilY = centerY + ( flAngleToScreenPixel * math_sin( math_rad( punchAngle.x ) ) );
+	
+	local diffX = recoilX - centerX;
+	local diffY = recoilY - centerY;
+	
+	if (5 > diffX and diffX > -5) and (5 > diffY and diffY > -5) then
+		return;
+	end
+	
+	draw.Color(settingColor:GetValue());
+	draw.FilledRect(recoilX - 3, recoilY - 1, recoilX + 3, recoilY + 1);
+	draw.FilledRect(recoilX - 1, recoilY - 3, recoilX + 1, recoilY + 3);
+end);


### PR DESCRIPTION
works with all fovs i tested (unlike original)
should be more accurate, due to using game's code
added an option to use game's recoil crosshair
when in-game crosshair is enabled, custom crosshair is drawn while scoping with SG and AUG
works when spectating